### PR TITLE
 [IMP] add warehouse selection to ecommerce

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import controllers
+from . import models

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -17,7 +17,7 @@
     ],
     'assets': {
         'web.assets_frontend': [
-            'gse_custo/static/src/js/variant_mixin.js',
+            'gse_website_sale_stock/static/src/js/variant_mixin.js',
         ],
     },
 }

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -15,6 +15,9 @@
     ],
     'data': [
     ],
+    'demo': [
+        'data/demo.xml',
+    ],
     'assets': {
         'web.assets_frontend': [
             'gse_website_sale_stock/static/src/js/variant_mixin.js',

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+{
+    'name': "gse_website_sale_stock",
+    'summary': """Customizations de l'ecommerce pour Goshop Energy""",
+    'description': """""",
+    'author': "Sébastien Bühl",
+    'website': "http://www.buhl.be",
+    'category': 'Customizations',
+    'version': '0.1',
+    'license': 'LGPL-3',
+
+    # any module necessary for this one to work correctly
+    'depends': [
+        'website_sale_stock',
+    ],
+    'data': [
+    ],
+    'assets': {
+        'web.assets_frontend': [
+            'gse_custo/static/src/js/variant_mixin.js',
+        ],
+    },
+}

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import main

--- a/controllers/main.py
+++ b/controllers/main.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+from odoo.addons.website_sale.controllers.main import WebsiteSale
+from odoo.http import request
+
+
+class WebsiteSale(WebsiteSale):
+
+    def _prepare_product_values(self, product, category, search, **kwargs):
+        gse_forced_warehouse_id = int(request.params.pop('gse_forced_warehouse_id', 0))
+        if gse_forced_warehouse_id and gse_forced_warehouse_id in request.env['stock.warehouse'].sudo().search([
+            ('company_id', '=', request.website.company_id.id)]
+        ).ids:
+            request.session['GSE_FORCED_WAREHOUSE_ID'] = gse_forced_warehouse_id
+            order = request.website.sale_get_order()
+            if order and order.state == 'draft':
+                order.warehouse_id = gse_forced_warehouse_id
+
+        return super()._prepare_product_values(product, category, search, **kwargs)

--- a/controllers/main.py
+++ b/controllers/main.py
@@ -16,4 +16,8 @@ class WebsiteSale(WebsiteSale):
             if order and order.state == 'draft':
                 order.warehouse_id = gse_forced_warehouse_id
 
+                for line in order.order_line:
+                    if line.exists():
+                        order._cart_update(product_id=line.product_id.id, line_id=line.id, add_qty=0)
+
         return super()._prepare_product_values(product, category, search, **kwargs)

--- a/data/demo.xml
+++ b/data/demo.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+<data noupdate="1">
+
+    <record id="product_delivery_01" model="product.product">
+        <field name="name">STOCK DEMO</field>
+        <field name="standard_price">55.0</field>
+        <field name="list_price">70.0</field>
+        <field name="detailed_type">product</field>
+        <field name="is_published">True</field>
+        <field name="allow_out_of_stock_order">False</field>
+        <field name="show_availability">True</field>
+        <field name="available_threshold">999</field>
+    </record>
+
+    <record id="website.default_website" model="website">
+        <field name="domain">http://127.0.0.1:8069/</field>
+    </record>
+    <record id="website.website2" model="website">
+        <field name="domain">http://127.0.0.2:8069/</field>
+        <field name="company_id" ref="stock.res_company_1"/>
+    </record>
+
+    <!-- Warehouses -->
+    <record id="warehouse0" model="stock.warehouse">
+        <field name="name">Company1WH2</field>
+        <field name="code">Company1WH2</field>
+    </record>
+
+    <!-- Inventory Stock -->
+    <record id="stock_inventory_1" model="stock.quant">
+        <field name="product_id" ref="gse_website_sale_stock.product_delivery_01"/>
+        <field name="inventory_quantity">10.0</field>
+        <field name="location_id" model="stock.location" eval="obj().env.ref('stock.warehouse0').lot_stock_id.id"/>
+    </record>
+    <record id="stock_inventory_2" model="stock.quant">
+        <field name="product_id" ref="gse_website_sale_stock.product_delivery_01"/>
+        <field name="inventory_quantity">5.0</field>
+        <field name="location_id" model="stock.location" eval="obj().env.ref('gse_website_sale_stock.warehouse0').lot_stock_id.id"/>
+    </record>
+    <record id="stock_inventory_3" model="stock.quant">
+        <field name="product_id" ref="gse_website_sale_stock.product_delivery_01"/>
+        <field name="inventory_quantity">22.0</field>
+        <field name="location_id" model="stock.location" eval="obj().env.ref('stock.stock_warehouse_shop0').lot_stock_id.id"/>
+    </record>
+    <function model="stock.quant" name="action_apply_inventory">
+        <function eval="[[('id', 'in', (ref('stock_inventory_1'),
+                                        ref('stock_inventory_2'),
+                                        ref('stock_inventory_3'),
+                                        ))]]" model="stock.quant" name="search"/>
+    </function>
+
+</data>
+</odoo>

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import product_template
+from . import website

--- a/models/product_template.py
+++ b/models/product_template.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    def _get_combination_info(self, combination=False, product_id=False, add_qty=1, pricelist=False, parent_combination=False, only_template=False):
+        combination_info = super()._get_combination_info(
+            combination=combination, product_id=product_id, add_qty=add_qty, pricelist=pricelist,
+            parent_combination=parent_combination, only_template=only_template)
+
+        if combination_info['product_id']:
+            product = self.env['product.product'].sudo().browse(combination_info['product_id'])
+            website = self.env['website'].get_current_website()
+            combination_info.update({
+                'gse_warehouses_qty_custo': [{
+                    'id': wh.id,
+                    'name': wh.name,
+                    'free_qty': product.with_context(warehouse=wh.id).free_qty,
+                    'selected': website._get_warehouse_available() == wh.id,
+                } for wh in self.env['stock.warehouse'].sudo().search([('company_id', '=', website.company_id.id)])],
+            })
+        else:
+            combination_info.update({
+                'gse_warehouses_qty_custo': [],
+            })
+
+        return combination_info

--- a/models/product_template.py
+++ b/models/product_template.py
@@ -14,16 +14,27 @@ class ProductTemplate(models.Model):
         if combination_info['product_id']:
             product = self.env['product.product'].sudo().browse(combination_info['product_id'])
             website = self.env['website'].get_current_website()
+            # Sudo to get website from other companies?
+            all_website_companies = self.env['website'].sudo().search([('domain', '!=', False)]).company_id
             combination_info.update({
+                'gse_warehouses_other_companies_qty_custo': [{
+                    'id': company.id,
+                    'name': company.name,
+                    'domain': company.website_id.domain,
+                    'address': company.partner_id.with_context(html_format=True, show_address_only=True).name_get()[0][1],  # contact_address_complete,
+                    'selected': website.company_id.id == company.id,
+                } for company in all_website_companies],
                 'gse_warehouses_qty_custo': [{
                     'id': wh.id,
                     'name': wh.name,
+                    'address': wh.partner_id.with_context(html_format=True, show_address_only=True).name_get()[0][1],
                     'free_qty': product.with_context(warehouse=wh.id).free_qty,
                     'selected': website._get_warehouse_available() == wh.id,
                 } for wh in self.env['stock.warehouse'].sudo().search([('company_id', '=', website.company_id.id)])],
             })
         else:
             combination_info.update({
+                'gse_warehouses_other_companies_qty_custo': [],
                 'gse_warehouses_qty_custo': [],
             })
 

--- a/models/website.py
+++ b/models/website.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models
+from odoo.http import request
+
+
+class Website(models.Model):
+    _inherit = 'website'
+
+    def _get_warehouse_available(self):
+        if request and request.session.get('GSE_FORCED_WAREHOUSE_ID'):
+            gse_wh_id = int(request.session['GSE_FORCED_WAREHOUSE_ID'])
+            if gse_wh_id in request.env['stock.warehouse'].sudo().search([('company_id', '=', self.company_id.id)]).ids:
+                return gse_wh_id
+            else:
+                request.session.pop('GSE_FORCED_WAREHOUSE_ID')
+        return super()._get_warehouse_available()

--- a/static/src/js/variant_mixin.js
+++ b/static/src/js/variant_mixin.js
@@ -1,0 +1,52 @@
+odoo.define('gse_website_sale_stock.VariantMixin', function (require) {
+'use strict';
+
+const publicWidget = require('web.public.widget');
+const core = require('web.core');
+const Dialog = require('web.Dialog');
+const QWeb = core.qweb;
+
+require('website_sale.website_sale');
+
+publicWidget.registry.WebsiteSale.include({
+    events: Object.assign({}, publicWidget.registry.WebsiteSale.prototype.events, {
+        'click .gse_change_warehouse': '_onChangeWarehouseClick',
+    }),
+    xmlDependencies: (publicWidget.registry.WebsiteSale.prototype.xmlDependencies || [])
+        .concat([
+            '/gse_website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml',
+            '/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml', // Needed for inherit?
+        ]),
+
+    _onChangeWarehouseClick(ev) {
+        const gseWhQty = $(ev.target).data('gse-wh-qty');
+        const dialog = new Dialog(this, {
+            size: 'medium',
+            title: 'Select another warehouse',
+            technical: false,
+            $content: QWeb.render('gse_website_sale_stock.popup_content_warehouse_select', {
+                'qty': gseWhQty,
+            }),
+            buttons: [
+                {
+                    text: "Save",
+                    classes: 'btn-primary',
+                    close: true,
+                    click: function () {
+                        const selectedWarehouse = dialog.$el.find('input[name="gse_select_warehouse"]:checked');
+                        const whId = selectedWarehouse[0].value;
+                        const search = $.deparam(window.location.search.substring(1));
+                        search['gse_forced_warehouse_id'] = whId;
+                        window.location.search = $.param(search);
+                    },
+                },
+                {
+                    text: "Cancel",
+                    close: true,
+                },
+            ],
+        }).open();
+    },
+});
+
+});

--- a/static/src/js/variant_mixin.js
+++ b/static/src/js/variant_mixin.js
@@ -10,6 +10,7 @@ require('website_sale.website_sale');
 
 publicWidget.registry.WebsiteSale.include({
     events: Object.assign({}, publicWidget.registry.WebsiteSale.prototype.events, {
+        'click .gse_change_company': '_onChangeCompanyClick',
         'click .gse_change_warehouse': '_onChangeWarehouseClick',
     }),
     xmlDependencies: (publicWidget.registry.WebsiteSale.prototype.xmlDependencies || [])
@@ -38,6 +39,35 @@ publicWidget.registry.WebsiteSale.include({
                         const search = $.deparam(window.location.search.substring(1));
                         search['gse_forced_warehouse_id'] = whId;
                         window.location.search = $.param(search);
+                    },
+                },
+                {
+                    text: "Cancel",
+                    close: true,
+                },
+            ],
+        }).open();
+    },
+
+    _onChangeCompanyClick(ev) {
+        const gseWebsiteCompanies = $(ev.target).data('gse-website-companies');
+        const dialog = new Dialog(this, {
+            size: 'medium',
+            title: 'Select another country',
+            technical: false,
+            $content: QWeb.render('gse_website_sale_stock.popup_content_company_select', {
+                'companies': gseWebsiteCompanies,
+            }),
+            buttons: [
+                {
+                    text: "Save",
+                    classes: 'btn-primary',
+                    close: true,
+                    click: function () {
+                        const selectedWarehouse = dialog.$el.find('input[name="gse_select_company"]:checked');
+                        const companyDomain = selectedWarehouse[0].value;
+                        let currentUrl = new URL(window.location);
+                        window.location = currentUrl.href.replace(currentUrl.origin, companyDomain);
                     },
                 },
                 {

--- a/static/src/xml/website_sale_stock_product_availability.xml
+++ b/static/src/xml/website_sale_stock_product_availability.xml
@@ -2,10 +2,17 @@
 
 <templates>
     <t t-extend="website_sale_stock.product_availability">
-        <t t-jquery="#threshold_message" t-operation="append">
-            <a href="#" class="gse_change_warehouse" t-att-data-gse-wh-qty="JSON.stringify(gse_warehouses_qty_custo)">
-                Check quantity in other warehouse
-            </a>
+        <t t-jquery="#threshold_message" t-operation="after">
+            <t t-if="show_availability">
+                <br/>
+                <a href="#" class="gse_change_warehouse" t-att-data-gse-wh-qty="JSON.stringify(gse_warehouses_qty_custo)">
+                    <i class="fa fa-building-o"/> Check quantity in other warehouse
+                </a>
+                <br/>
+                <a href="#" class="gse_change_company" t-att-data-gse-website-companies="JSON.stringify(gse_warehouses_other_companies_qty_custo)">
+                    <i class="fa fa-globe"/> Change country
+                </a>
+            </t>
         </t>
     </t>
 
@@ -28,6 +35,25 @@
                 </label>
             </div>
             <small><i>Note that changing the warehouse location might change the quantity of other products you may already have in your cart.</i></small>
+        </div>
+    </t>
+
+    <t t-name="gse_website_sale_stock.popup_content_company_select">
+        <div>
+            <div class="card">
+                <label t-foreach="companies" t-as="company">
+                    <div class="card-body d-flex" style="border-top: 1px solid #dddddd;">
+                        <div class="flex-grow-1">
+                            <span><b t-esc="company.name"/></span><br />
+                            <i class="fa fa-map-marker mr-1" style="color:orange;"/><t t-raw="company.address"/>
+                        </div>
+                        <div class="align-self-center">
+                            <input name="gse_select_company" type="radio"
+                                   t-att-value="company.domain" t-att-checked="company.selected || undefined"/>
+                        </div>
+                    </div>
+                </label>
+            </div>
         </div>
     </t>
 </templates>

--- a/static/src/xml/website_sale_stock_product_availability.xml
+++ b/static/src/xml/website_sale_stock_product_availability.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates>
+    <t t-extend="website_sale_stock.product_availability">
+        <t t-jquery="#threshold_message" t-operation="append">
+            <a href="#" class="gse_change_warehouse" t-att-data-gse-wh-qty="JSON.stringify(gse_warehouses_qty_custo)">
+                Check quantity in other warehouse
+            </a>
+        </t>
+    </t>
+
+    <t t-name="gse_website_sale_stock.popup_content_warehouse_select">
+        <div>
+            <div class="card">
+                <label t-foreach="qty" t-as="wh">
+                    <div class="card-body d-flex" style="border-top: 1px solid #dddddd;">
+                        <div class="flex-grow-1">
+                            <span><b t-esc="wh.name"/></span><br />
+                            <p><strong><t t-esc="wh.free_qty"/> </strong>Units left in stock.</p>
+                            <i class="fa fa-circle mr-1" style="color:red;"/>Something to show here<br/>
+                            <i class="fa fa-map-marker mr-1" style="color:orange;"/>Like the address maybe?
+                        </div>
+                        <div class="align-self-center">
+                            <input name="gse_select_warehouse" type="radio"
+                                   t-att-value="wh.id" t-att-checked="wh.selected || undefined"/>
+                        </div>
+                    </div>
+                </label>
+            </div>
+            <small><i>Note that changing the warehouse location might change the quantity of other products you may already have in your cart.</i></small>
+        </div>
+    </t>
+</templates>


### PR DESCRIPTION
```
[IMP] add warehouse selection to ecommerce
 
- Possible to see stock in other warehouse
- Can select a different one
- Hint to mention than during checkout the quantities of already added
  product might be altered (eg if come from another warehouse with less
  or no qty) -> Note that Odoo already has something that will hint the
  user that we reduced qty on payment page (orange warning icon)
```
```
[IMP] ecommerce allow changing website to see qty in other country

As discussed:
- 1 website = 1 domain = 1 company = 1 country
- Being on a website, you can see the stock from all the warehouse
  from the company of the current website (done in previous commits)
- But now with this commit, you can also change country to see stock in
  those country: it will change domain, meaning changing website and
  basically fallbacking to previous point: you can see the qty from this
  new website's company's WHs.
```