### PR TITLE
[IMP] Partner Level on pricelist + max amount order on PL

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -11,15 +11,18 @@
 
     # any module necessary for this one to work correctly
     'depends': [
+        'website_crm_partner_assign',  # res_partner.grade_id
         'website_sale_stock',
     ],
     'data': [
+        'views/product_pricelist_views.xml',
     ],
     'demo': [
         'data/demo.xml',
     ],
     'assets': {
         'web.assets_frontend': [
+            'gse_website_sale_stock/static/src/js/max_amount_toaster.js',
             'gse_website_sale_stock/static/src/js/variant_mixin.js',
         ],
     },

--- a/controllers/main.py
+++ b/controllers/main.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from odoo.addons.website_sale.controllers.main import WebsiteSale
+from odoo import http
+from odoo.addons.website_sale.controllers.main import PaymentPortal, WebsiteSale
 from odoo.http import request
+from odoo.exceptions import ValidationError
+
+from werkzeug.urls import url_decode, url_encode, url_parse
 
 
 class WebsiteSale(WebsiteSale):
@@ -21,3 +25,36 @@ class WebsiteSale(WebsiteSale):
                         order._cart_update(product_id=line.product_id.id, line_id=line.id, add_qty=0)
 
         return super()._prepare_product_values(product, category, search, **kwargs)
+
+    @http.route(['/shop/change_pricelist/<model("product.pricelist"):pl_id>'], type='http', auth="public", website=True, sitemap=False)
+    def pricelist_change(self, pl_id, **post):
+        res = super().pricelist_change(pl_id, **post)
+        # If the selected PL has a maximum amount linked to it, and that it was
+        # really selected, inform the user through a toast about the max amount.
+        if (
+            pl_id.max_authorized_eshop_amount
+            and request.session['website_sale_current_pl'] == pl_id.id
+        ):
+            decoded_url = url_parse(res.location)
+            args = url_decode(decoded_url.query)
+            args['show_max_amount_toast'] = pl_id.max_authorized_eshop_amount
+            redirect_url = decoded_url.replace(query=url_encode(args)).to_url()
+            return request.redirect(
+                redirect_url,
+                code=res.status_code,
+            )
+        return res
+
+
+class PaymentPortal(PaymentPortal):
+
+    @http.route()
+    def shop_payment_transaction(self, *args, **kwargs):
+        """ Payment transaction override to double check cart quantities before
+        placing the order
+        """
+        order = request.website.sale_get_order()
+        max_authorized_eshop_amount = order.pricelist_id.max_authorized_eshop_amount
+        if max_authorized_eshop_amount and order.amount_total > max_authorized_eshop_amount:
+            raise ValidationError("Le montant de la commande dépasse le maximum autorise (%s)." % max_authorized_eshop_amount)
+        return super().shop_payment_transaction(*args, **kwargs)

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 
+from . import product_pricelist
 from . import product_template
 from . import website

--- a/models/product_pricelist.py
+++ b/models/product_pricelist.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+from odoo.osv import expression
+
+
+class ProductPricelist(models.Model):
+    _inherit = "product.pricelist"
+
+    grade_ids = fields.Many2many('res.partner.grade', string='Partner Level')
+    max_authorized_eshop_amount = fields.Float(default=0.0, help="Maximum amount allowed on eshop with this pricelist.")
+
+    def _is_available_on_website(self, website_id):
+        """ To be able to be used on a website, a pricelist should either:
+        - Have its `website_id` set to current website (specific pricelist).
+        - Have no `website_id` set and should be `selectable` (generic pricelist)
+          or should have a `code` (generic promotion).
+        - Have no `company_id` or a `company_id` matching its website one.
+
+        Note: A pricelist without a website_id, not selectable and without a
+              code is a backend pricelist.
+
+        Change in this method should be reflected in `_get_website_pricelists_domain`.
+        """
+        self.ensure_one()
+        if self.grade_ids and self.env.user.grade_id not in self.grade_ids:
+            return False
+        return super()._is_available_on_website(website_id)
+
+    def _get_website_pricelists_domain(self, website_id):
+        ''' Check above `_is_available_on_website` for explanation.
+        Change in this method should be reflected in `_is_available_on_website`.
+        '''
+        return expression.AND([
+            super()._get_website_pricelists_domain(website_id),
+            [
+                '|',
+                ('grade_ids', '=', False),
+                ('grade_ids', '=', self.env.user.grade_id.id),
+            ]
+        ])

--- a/static/src/js/max_amount_toaster.js
+++ b/static/src/js/max_amount_toaster.js
@@ -1,0 +1,24 @@
+/** @odoo-module **/
+
+import publicWidget from 'web.public.widget';
+import {registry} from "@web/core/registry";
+
+const MaxAmountToasterWidget = publicWidget.Widget.extend({
+    start() {
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('show_max_amount_toast')) {
+            this.displayNotification({
+                message: "Le montant maximum de la commande avec cette liste de prix est de " + params.get('show_max_amount_toast'),
+                type: 'warning',
+            });
+        }
+        return this._super(...arguments);
+    },
+});
+
+registry.category("public_root_widgets").add("MaxAmountToasterWidget", {
+    Widget: MaxAmountToasterWidget,
+    selector: '#wrap',
+});
+
+export default MaxAmountToasterWidget;

--- a/views/product_pricelist_views.xml
+++ b/views/product_pricelist_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record model="ir.ui.view" id="product_pricelist_form_view">
+        <field name="name">product.pricelist.website.form</field>
+        <field name="model">product.pricelist</field>
+        <field name="inherit_id" ref="product.product_pricelist_view"/>
+        <field name="arch" type="xml">
+            <field name="country_group_ids" position="after">
+                <field name="grade_ids" widget="many2many_tags"/>
+                <field name="max_authorized_eshop_amount" widget="monetary"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Be able to limit the visibility and the selection of the price lists on the website (using the partner grade_id (partner lvl)
- On website, prevent to order if amount > 50k, with the price list "Ex Works".
- Warning when select the price list "ex works" (toaster)

Fixes https://github.com/sbuhl/gse_website_sale_stock/issues/2